### PR TITLE
Use `env` for shebang instead of hardcoding shell

### DIFF
--- a/functions/fzf_helpers/fzf_command.sh
+++ b/functions/fzf_helpers/fzf_command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: $0 STATE_FILE COMMAND [ARG ...] 
 

--- a/functions/fzf_helpers/fzf_preview.sh
+++ b/functions/fzf_helpers/fzf_preview.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: $0 FILE_OR_DIRECTORY [STATE_FILE]
 


### PR DESCRIPTION
Not all distributions have `/bin/bash`.